### PR TITLE
Fix Veracode and change Validations on docs

### DIFF
--- a/.github/workflows/veracode.yaml
+++ b/.github/workflows/veracode.yaml
@@ -51,7 +51,7 @@ jobs:
 
       #Copy the jar to directory which gets uploaded to Veracode
       - name: Copy Pool JAR
-        run: cp target/value-added-service-1.0.4.jar target/veracode/value-added-service-1.0.4.jar
+        run: cp target/value-added-service-*.jar target/veracode/value-added-service.jar
 
       - name: Run Veracode Upload And Scan
         uses: veracode/veracode-uploadandscan-action@0.2.1

--- a/.github/workflows/veracode.yaml
+++ b/.github/workflows/veracode.yaml
@@ -51,7 +51,7 @@ jobs:
 
       #Copy the jar to directory which gets uploaded to Veracode
       - name: Copy Pool JAR
-        run: cp target/value-added-service-1.0.0.jar target/veracode/value-added-service-1.0.0.jar
+        run: cp target/value-added-service-1.0.4.jar target/veracode/value-added-service-1.0.4.jar
 
       - name: Run Veracode Upload And Scan
         uses: veracode/veracode-uploadandscan-action@0.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.4] -  2023-03-02
+
+### Changed
+
+- Fix image that veracode is validating 
+- Fix structure of folders on README.md
+- Fix dockerfile removing the same EXPOSE block
+- Fix helm chart readme on current version released
+
+
 ## [1.0.3] -  2023-02-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix image that veracode is validating 
 - Fix structure of folders on README.md
 - Fix dockerfile removing the same EXPOSE block
-- Fix helm chart readme on current version released
+- Fix Helm chart README.md on current version released
 - Fix Header on charts to be validated with Company group
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.4] -  2023-03-02
 
-### Changed
+### Fixes
 
 - Fix image that veracode is validating 
 - Fix structure of folders on README.md
-- Fix dockerfile removing the same EXPOSE block
-- Fix Helm chart README.md on current version released
 - Fix Header on charts to be validated with Company group
 
+### Changed 
+- Change structure of folders on README.md
+- Change Helm chart README.md on current version released
+
+### Removed 
+- Dockerfile removing the same EXPOSE block
 
 ## [1.0.3] -  2023-02-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 
-- Fix image that veracode is validating 
-- Fix structure of folders on README.md
+- Fix image that veracode is validating
 - Fix Header on charts to be validated with Company group
 
 ### Changed 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix structure of folders on README.md
 - Fix dockerfile removing the same EXPOSE block
 - Fix helm chart readme on current version released
+- Fix Header on charts to be validated with Company group
 
 
 ## [1.0.3] -  2023-02-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - First Release 
 
-[Unreleased]: https://github.com/eclipse-tractusx/vas-country-risk-backend/compare
-
-[1.0.0]: https://github.com/eclipse-tractusx/vas-country-risk-backend/compare

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,8 @@ FROM maven:3.8-openjdk-18 as maven
 COPY ./pom.xml /pom.xml
 COPY ./src ./src
 
-EXPOSE 8080
-EXPOSE 80
-EXPOSE 433
-
 RUN mvn clean package
 
-EXPOSE 8080
-EXPOSE 80
-EXPOSE 433
 
 #CMD exec /bin/bash -c "trap : TERM INT; sleep infinity & wait"
 # Copy the jar and build image

--- a/README.md
+++ b/README.md
@@ -78,22 +78,25 @@ Inside the java folder, there is the source code for the project, which is divid
 and follows the mainly used project structure in most Spring Boot projects.
 
 ```sh
-       └───catenax
-           └───valueaddedservice
-               ├───config
-               ├───constants
-               ├───domain
-               │   └───enumeration
-               ├───dto
-               ├───interceptors
-               ├───repository
-               ├───service
-               │   ├───csv
-               │   ├───logic
-               │   └───mapper
-               ├───utils
-               └───web
-                   └───rest
+       └───org
+           └───eclipse
+               └───tractusx
+                   └───valueaddedservice
+                       ├───config
+                       ├───constants
+                       ├───domain
+                       │   └───enumeration
+                       ├───dto
+                       │   └───ShareDTOs
+                       ├───interceptors
+                       ├───repository
+                       ├───service
+                       │   ├───csv
+                       │   ├───logic
+                       │   └───mapper
+                       ├───utils
+                       └───web
+                           └───rest
 ```
 
 ## API sample endpoints

--- a/charts/country-risk-backend-charts/Chart.yaml
+++ b/charts/country-risk-backend-charts/Chart.yaml
@@ -1,4 +1,5 @@
-###############################################################
+################################################################################
+# Copyright (c) 2022,2023 BMW Group AG
 # Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
@@ -15,7 +16,7 @@
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-###############################################################
+################################################################################
 
 
 apiVersion: v2

--- a/charts/country-risk-backend-charts/Chart.yaml
+++ b/charts/country-risk-backend-charts/Chart.yaml
@@ -35,13 +35,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.0
+version: 2.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.0.3"
+appVersion: "1.0.4"
 
 dependencies:
   - name: postgresql

--- a/charts/country-risk-backend-charts/README.md
+++ b/charts/country-risk-backend-charts/README.md
@@ -14,7 +14,7 @@ helm install release_name ./charts/country-risk-backend-charts --namespace your_
 ```
 
 This will install a new release of the Country Risk in the given namespace.
-On default values this release deploys the latest image tagged as `"v1.0.4"` from the repository's GitHub Container Registry.
+On default values this release deploys the latest image tagged that its on the `.Chart.appVersion` from the repository's GitHub Container Registry.
 The application is run on default profile (you can run it on a dev profile or local).
 Additionally, the Helm deployment contains a PostgreSQL database which the Country Risk connects to.
 

--- a/charts/country-risk-backend-charts/README.md
+++ b/charts/country-risk-backend-charts/README.md
@@ -14,7 +14,7 @@ helm install release_name ./charts/country-risk-backend-charts --namespace your_
 ```
 
 This will install a new release of the Country Risk in the given namespace.
-On default values this release deploys the latest image tagged as `v1.0.0` from the repository's GitHub Container Registry.
+On default values this release deploys the latest image tagged as `"v1.0.4"` from the repository's GitHub Container Registry.
 The application is run on default profile (you can run it on a dev profile or local).
 Additionally, the Helm deployment contains a PostgreSQL database which the Country Risk connects to.
 
@@ -32,7 +32,7 @@ In the following sections you can have a look at the most important configuratio
 
 Per default, the Helm deployment references a certain Country Risk release version where the newest Helm release points to the newest Country Risk version.
 This is a stable tag pointing to a fixed release version of the Country Risk.
-For your deployment you might want to follow the latest application releases instead.
+For your deployment you might want to follow the latest or a specific application releases instead
 
 In your values file you can overwrite the default tag:
 

--- a/charts/country-risk-backend-charts/templates/application-secret.yaml
+++ b/charts/country-risk-backend-charts/templates/application-secret.yaml
@@ -1,4 +1,5 @@
-###############################################################
+################################################################################
+# Copyright (c) 2022,2023 BMW Group AG 
 # Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
@@ -15,7 +16,7 @@
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-###############################################################
+################################################################################
 
 {{ if .Values.applicationSecret.enabled }}
 

--- a/charts/country-risk-backend-charts/templates/configmap.yaml
+++ b/charts/country-risk-backend-charts/templates/configmap.yaml
@@ -1,4 +1,5 @@
-###############################################################
+################################################################################
+# Copyright (c) 2022,2023 BMW Group AG
 # Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
@@ -15,7 +16,7 @@
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-###############################################################
+################################################################################
 
 {{ if .Values.configmap.create }}
 apiVersion: v1

--- a/charts/country-risk-backend-charts/templates/deployment.yaml
+++ b/charts/country-risk-backend-charts/templates/deployment.yaml
@@ -1,4 +1,5 @@
-###############################################################
+################################################################################
+# Copyright (c) 2022,2023 BMW Group AG
 # Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
@@ -15,7 +16,7 @@
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-###############################################################
+################################################################################
 
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/country-risk-backend-charts/templates/ingress.yaml
+++ b/charts/country-risk-backend-charts/templates/ingress.yaml
@@ -1,4 +1,5 @@
-###############################################################
+################################################################################
+# Copyright (c) 2022,2023 BMW Group AG
 # Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
@@ -15,7 +16,7 @@
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-###############################################################
+################################################################################
 
 {{ if .Values.ingress.enabled }}
 

--- a/charts/country-risk-backend-charts/templates/secret-pgadmin4.yaml
+++ b/charts/country-risk-backend-charts/templates/secret-pgadmin4.yaml
@@ -1,4 +1,5 @@
-###############################################################
+################################################################################
+# Copyright (c) 2022,2023 BMW Group AG
 # Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
@@ -15,7 +16,7 @@
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-###############################################################
+################################################################################
 
 apiVersion: v1
 kind: Secret

--- a/charts/country-risk-backend-charts/templates/service.yaml
+++ b/charts/country-risk-backend-charts/templates/service.yaml
@@ -1,4 +1,5 @@
-###############################################################
+################################################################################
+# Copyright (c) 2022,2023 BMW Group AG
 # Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
@@ -15,7 +16,7 @@
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-###############################################################
+################################################################################
 
 apiVersion: v1
 kind: Service

--- a/charts/country-risk-backend-charts/values-dev.yaml
+++ b/charts/country-risk-backend-charts/values-dev.yaml
@@ -1,4 +1,5 @@
-###############################################################
+################################################################################
+# Copyright (c) 2022,2023 BMW Group AG
 # Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
@@ -15,7 +16,7 @@
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-###############################################################
+################################################################################
 
 springProfiles:
   - dev

--- a/charts/country-risk-backend-charts/values-int.yaml
+++ b/charts/country-risk-backend-charts/values-int.yaml
@@ -1,4 +1,5 @@
-###############################################################
+################################################################################
+# Copyright (c) 2022,2023 BMW Group AG
 # Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
@@ -15,7 +16,7 @@
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-###############################################################
+################################################################################
 
 springProfiles:
   - int

--- a/charts/country-risk-backend-charts/values.yaml
+++ b/charts/country-risk-backend-charts/values.yaml
@@ -1,4 +1,5 @@
-###############################################################
+################################################################################
+# Copyright (c) 2022,2023 BMW Group AG
 # Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
@@ -15,7 +16,7 @@
 # under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-###############################################################
+################################################################################
 
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--	 Copyright (c) 2022,2023 BMW Group AG-->
+<!--	 Copyright (c) 2022,2023 Contributors to the Eclipse Foundation-->
+
+<!--	 See the NOTICE file(s) distributed with this work for additional-->
+<!--	 information regarding copyright ownership.-->
+
+<!--	 This program and the accompanying materials are made available under the-->
+<!--	 terms of the Apache License, Version 2.0 which is available at-->
+<!--	 https://www.apache.org/licenses/LICENSE-2.0.-->
+
+<!--	 Unless required by applicable law or agreed to in writing, software-->
+<!--	 distributed under the License is distributed on an "AS IS" BASIS, WITHOUT-->
+<!--	 WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the-->
+<!--	 License for the specific language governing permissions and limitations-->
+<!--	 under the License.-->
+
+<!--	 SPDX-License-Identifier: Apache-2.0-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+
+
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
@@ -29,7 +49,7 @@
 		<sonar.coverage.jacoco.xmlReportPaths>${project.reporting.outputDirectory}/target/jacoco-report/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
 		<sonar.organization>catenax-ng</sonar.organization>
 		<sonar.projectKey>catenax-ng_product-value-added-service</sonar.projectKey>
-		<sonar.coverage.exclusions>src/main/java/org/eclipse/tractusx/valueaddedservice/dto/**/*.*,src/main/java/org/eclipse/tractusx/valueaddedservice/domain/**/*.*¨</sonar.coverage.exclusions>
+		<sonar1.coverage.exclusions>src/main/java/org/eclipse/tractusx/valueaddedservice/dto//.,src/main/java/org/eclipse/tractusx/valueaddedservice/domain//.¨</sonar1.coverage.exclusions>
 		<jacoco.version>0.8.7</jacoco.version>
 		<org.owasp.esapi>2.5.1.0</org.owasp.esapi>
 		<spring-boot-starter-oauth2-resource-server>3.0.1</spring-boot-starter-oauth2-resource-server>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>org.eclipse.tractusx</groupId>
 	<artifactId>value-added-service</artifactId>
-	<version>1.0.3</version>
+	<version>1.0.4</version>
 	<name>value-added-service</name>
 	<description>Project to Validate Country Risks Score</description>
 	<properties>


### PR DESCRIPTION
Fix image that veracode is validating 
Change structure of folders on README.md
Fix Header on charts to be validated with Company group
Change Helm chart README.md on current version released
Dockerfile removing the same EXPOSE block