### PR TITLE
fix: reflect correct leadingrepo at .tractusx

### DIFF
--- a/.tractusx
+++ b/.tractusx
@@ -1,1 +1,1 @@
-leadingRepository: "https://github.com/eclipse-tractusx/vas-country-risk-frontend"
+leadingRepository: "https://github.com/eclipse-tractusx/vas-country-risk"


### PR DESCRIPTION
PR to reflect correct metadata leadingrepository in order to fix quality check dashboard mapping.

Updates https://github.com/eclipse-tractusx/sig-infra/issues/277