### PR TITLE
fix(Backend): Docker Notice Content

### DIFF
--- a/DOCKER_NOTICE.md
+++ b/DOCKER_NOTICE.md
@@ -1,18 +1,15 @@
 ## Notice for Docker image
 
-DockerHub: [https://hub.docker.com/u/tractusx](https://hub.docker.com/r/tractusx)
+DockerHub: [https://hub.docker.com/r/tractusx/vas-country-risk-backend](https://hub.docker.com/u/tractusx/vas-country-risk-backend)
 
 Eclipse Tractus-X product(s) installed within the image:
 
 **VAS Country Risk Backend**
 
-Eclipse Tractus-X product(s) installed within the image:
-
 - GitHub: https://github.com/eclipse-tractusx/vas-country-risk-backend 
 - Project home: https://projects.eclipse.org/projects/automotive.tractusx
-- Pool Dockerfile: https://github.com/eclipse-tractusx/vas-country-risk-backend/blob/main/Dockerfile
+- Dockerfile: https://github.com/eclipse-tractusx/vas-country-risk-backend/blob/main/Dockerfile
 - Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/vas-country-risk-backend/blob/main/LICENSE)
-
 
 **Used base image**
 

--- a/README.md
+++ b/README.md
@@ -133,15 +133,9 @@ and follows the mainly used project structure in most Spring Boot projects.
 
 ## Notice for Docker image
 
-This application provides container images for demonstration purposes.
+Bellow you can find the information regarding docker notice md for this application.
 
-DockerHub: https://hub.docker.com/u/tractusx/vas-country-risk-backend
-
-Base image: eclipse-temurin:17-jre-alpine
-
-- Dockerfile: [nginxinc/nginx-unprivileged:alpine](https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/Dockerfile-alpine.template)
-- GitHub project: [https://github.com/nginxinc/docker-nginx-unprivileged](https://github.com/nginxinc/docker-nginx-unprivileged)
-- DockerHub: [https://hub.docker.com/r/nginxinc/nginx-unprivileged](https://hub.docker.com/r/nginxinc/nginx-unprivileged)
+* [Vas Country Risk Backend](./DOCKER_NOTICE.md)
 
 ## License
 


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
- Fix Docker Notice Content
- Changed urls for https://hub.docker.com/r/tractusx/vas-country-risk-backend
- Updated Readme.md



## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
