### PR TITLE
Kicks Scan Fix

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -34,15 +34,13 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.14.0
         with:
           scan-type: "config"
-          # ignore-unfixed: true
-          exit-code: "1"
           hide-progress: false
           format: "sarif"
           output: "trivy-results1.sarif"
-          severity: "CRITICAL,HIGH"
+          vuln-type: "os,library"
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ FROM maven:3.8-openjdk-18 as maven
 
 COPY ./pom.xml /pom.xml
 COPY ./src ./src
-COPY LICENSE NOTICE.md DEPENDENCIES SECURITY.md /app
+COPY LICENSE NOTICE.md DEPENDENCIES SECURITY.md /app/
 
 RUN mvn clean package -DskipTests
 


### PR DESCRIPTION
## Description
Add closer / on copy command on docker file to fix Kicks issue finding

Issue: [[HIGH] Copy With More Than Two Arguments Not Ending With Slash: Dockerfile#L25](https://github.com/eclipse-tractusx/vas-country-risk-backend/commit/78b08f504777f6ebab2d0fc0e3b77da7dadb890f#annotation_15943797789)

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
