### PR TITLE
Fix trivy scan

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ WORKDIR /app
 
 COPY --chown=${UID}:${GID} --from=maven target/value-added-service-*.jar app.jar
 
+RUN apk update && apk upgrade --no-cache libssl3 libcrypto3
 
 USER ${UID}:${GID}
 


### PR DESCRIPTION
## Description
Fix for Trivy scan regarding new findings on eclipse base image

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
