### PR TITLE
Remove lib with vulnerability and refactor unit test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Changelog
 
+
+
+## [1.2.2] - 2023-11-30
+
+### Removed
+- Removed org.owasp.esapi lib 
+
+### Changed
+- Change Unit Test from testRestTemplate to webTestClient since testRestTemplate does not handle UNAUTHORIZED errors
+
 ## [1.2.1] - 2023-11-27
 
 ### Changed

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -16,14 +16,7 @@ maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.24.4, Apache-2.0, approved, cl
 maven/mavencentral/com.nimbusds/oauth2-oidc-sdk/9.43.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.opencsv/opencsv/5.7.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.zaxxer/HikariCP/5.0.1, Apache-2.0, approved, clearlydefined
-maven/mavencentral/commons-beanutils/commons-beanutils/1.9.4, Apache-2.0, approved, CQ12654
 maven/mavencentral/commons-codec/commons-codec/1.15, Apache-2.0 AND BSD-3-Clause AND LicenseRef-Public-Domain, approved, CQ22641
-maven/mavencentral/commons-collections/commons-collections/3.2.2, Apache-2.0, approved, CQ10385
-maven/mavencentral/commons-configuration/commons-configuration/1.10, Apache-2.0, approved, clearlydefined
-maven/mavencentral/commons-fileupload/commons-fileupload/1.5, Apache-2.0, approved, #7109
-maven/mavencentral/commons-io/commons-io/2.11.0, Apache-2.0, approved, CQ23745
-maven/mavencentral/commons-lang/commons-lang/2.6, Apache-2.0, approved, CQ6183
-maven/mavencentral/commons-logging/commons-logging/1.2, Apache-2.0, approved, CQ10162
 maven/mavencentral/io.hypersistence/hypersistence-tsid/2.0.0, MIT, approved, clearlydefined
 maven/mavencentral/io.hypersistence/hypersistence-utils-hibernate-60/3.5.1, Apache-2.0, approved, #9651
 maven/mavencentral/io.micrometer/micrometer-commons/1.11.5, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #9243
@@ -47,7 +40,7 @@ maven/mavencentral/io.netty/netty-transport-native-epoll/4.1.100.Final, Apache-2
 maven/mavencentral/io.netty/netty-transport-native-unix-common/4.1.100.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-transport/4.1.100.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.projectreactor.netty/reactor-netty-core/1.1.12, Apache-2.0, approved, #5946
-maven/mavencentral/io.projectreactor.netty/reactor-netty-http/1.1.12, Apache-2.0, approved, #6999
+maven/mavencentral/io.projectreactor.netty/reactor-netty-http/1.1.13, Apache-2.0, approved, #6999
 maven/mavencentral/io.projectreactor/reactor-core/3.5.11, Apache-2.0, approved, #5934
 maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.9, Apache-2.0, approved, #5947
 maven/mavencentral/io.swagger.core.v3/swagger-core-jakarta/2.2.9, Apache-2.0, approved, #5929
@@ -64,38 +57,25 @@ maven/mavencentral/javax.xml.bind/jaxb-api/2.3.1, CDDL-1.1 OR GPL-2.0-only WITH 
 maven/mavencentral/net.minidev/accessors-smart/2.4.11, Apache-2.0, approved, #7515
 maven/mavencentral/net.minidev/json-smart/2.4.11, Apache-2.0, approved, #3288
 maven/mavencentral/org.antlr/antlr4-runtime/4.10.1, BSD-3-Clause AND LicenseRef-Public-domain AND MIT AND LicenseRef-Unicode-TOU, approved, #7065
-maven/mavencentral/org.apache-extras.beanshell/bsh/2.0b6, Apache-2.0, approved, #1990
 maven/mavencentral/org.apache.commons/commons-collections4/4.4, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.commons/commons-lang3/3.12.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.commons/commons-text/1.10.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.apache.httpcomponents.client5/httpclient5/5.2.1, Apache-2.0, approved, #9605
-maven/mavencentral/org.apache.httpcomponents.core5/httpcore5-h2/5.2.3, Apache-2.0, approved, #10658
-maven/mavencentral/org.apache.httpcomponents.core5/httpcore5/5.2.3, Apache-2.0, approved, #9652
 maven/mavencentral/org.apache.logging.log4j/log4j-api/2.20.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.logging.log4j/log4j-to-slf4j/2.20.0, Apache-2.0, approved, #8799
 maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-core/10.1.15, Apache-2.0 AND (EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0) AND (CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0) AND W3C AND CC0-1.0, approved, #5949
 maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-el/10.1.15, Apache-2.0, approved, #6997
 maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-websocket/10.1.15, Apache-2.0, approved, #7920
-maven/mavencentral/org.apache.xmlgraphics/batik-constants/1.17, Apache-2.0, approved, #10158
-maven/mavencentral/org.apache.xmlgraphics/batik-css/1.17, Apache-2.0, approved, #10141
-maven/mavencentral/org.apache.xmlgraphics/batik-i18n/1.17, Apache-2.0, approved, #10154
-maven/mavencentral/org.apache.xmlgraphics/batik-shared-resources/1.17, Apache-2.0, approved, #10147
-maven/mavencentral/org.apache.xmlgraphics/batik-util/1.17, Apache-2.0, approved, #10150
-maven/mavencentral/org.apache.xmlgraphics/xmlgraphics-commons/2.9, Apache-2.0, approved, #10159
 maven/mavencentral/org.apiguardian/apiguardian-api/1.1.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.aspectj/aspectjweaver/1.9.20, EPL-1.0, approved, tools.aspectj
+maven/mavencentral/org.aspectj/aspectjweaver/1.9.20, Apache-2.0 AND BSD-3-Clause AND EPL-1.0 AND BSD-3-Clause AND Apache-1.1, approved, #7695
 maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.73, MIT, approved, #7892
 maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.73, MIT, approved, #7894
 maven/mavencentral/org.hibernate.orm/hibernate-core/6.2.6.Final, LGPL-2.1-only AND Apache-2.0 AND MIT AND CC-PDDC AND (EPL-2.0 OR BSD-3-Clause), approved, #9121
 maven/mavencentral/org.hibernate.validator/hibernate-validator/8.0.1.Final, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.htmlunit/neko-htmlunit/3.6.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.jboss.logging/jboss-logging/3.5.3.Final, Apache-2.0, approved, #9471
 maven/mavencentral/org.liquibase/liquibase-core/4.23.0, Apache-2.0, approved, #9650
 maven/mavencentral/org.mapstruct/mapstruct/1.5.5.Final, Apache-2.0, approved, #6277
 maven/mavencentral/org.openapitools/jackson-databind-nullable/0.2.6, Apache-2.0, approved, #3294
 maven/mavencentral/org.ow2.asm/asm/9.3, BSD-3-Clause, approved, clearlydefined
-maven/mavencentral/org.owasp.antisamy/antisamy/1.7.4, BSD-3-Clause, approved, clearlydefined
-maven/mavencentral/org.owasp.esapi/esapi/2.5.2.0, BSD-3-Clause AND CC-BY-SA-3.0 AND LicenseRef-Public-Domain, approved, #6274
 maven/mavencentral/org.postgresql/postgresql/42.6.0, BSD-2-Clause AND Apache-2.0, approved, #9159
 maven/mavencentral/org.projectlombok/lombok/1.18.28, MIT AND LicenseRef-Public-Domain, approved, CQ23907
 maven/mavencentral/org.reactivestreams/reactive-streams/1.0.4, CC0-1.0, approved, CQ16332
@@ -161,7 +141,3 @@ maven/mavencentral/org.zalando/problem-spring-common/0.26.0, MIT, approved, clea
 maven/mavencentral/org.zalando/problem-spring-web/0.26.0, MIT, approved, clearlydefined
 maven/mavencentral/org.zalando/problem-violations/0.26.0, MIT, approved, clearlydefined
 maven/mavencentral/org.zalando/problem/0.24.0, MIT, approved, clearlydefined
-maven/mavencentral/xerces/xercesImpl/2.12.2, Apache-2.0 AND W3C, approved, CQ23076
-maven/mavencentral/xml-apis/xml-apis-ext/1.3.04, Apache-2.0, approved, CQ1448
-maven/mavencentral/xml-apis/xml-apis/1.4.01, Apache-2.0 OR LicenseRef-Public-Domain OR W3C, approved, CQ9621
-maven/mavencentral/xom/xom/1.3.8, LGPL-2.1-only, approved, #6275

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,6 @@
             src/main/java/org/eclipse/tractusx/valueaddedservice/dto//.,src/main/java/org/eclipse/tractusx/valueaddedservice/domain//.¨
         </sonar1.coverage.exclusions>
         <jacoco.version>0.8.7</jacoco.version>
-        <org.owasp.esapi>2.5.2.0</org.owasp.esapi>
         <spring-boot-starter-oauth2>3.1.5</spring-boot-starter-oauth2>
         <spring-security-web-version>6.1.1</spring-security-web-version>
         <postgresql-version>42.6.0</postgresql-version>
@@ -240,11 +239,7 @@
             </exclusions>
         </dependency>
 
-        <dependency>
-            <groupId>org.owasp.esapi</groupId>
-            <artifactId>esapi</artifactId>
-            <version>${org.owasp.esapi}</version>
-        </dependency>
+
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>


### PR DESCRIPTION
## Description
Vulnerability detected in the org.owasp.esapi library, which was only used for logging error responses of unauthorized access.
Since the rest template did not handle these responses, the library for requests in these use cases was switched to webclient.
Refactoring only in unit tests, without the need for functional changes.


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
