### PR TITLE
Update Trivy and Veracode Scans and Findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added mapping for generic Endpoint
 - Added mapping for Pool lsa types
 
+### Fixes
+- Fix vulnerability on spring boot version and upgrade version to 3.1.7
+
 ## [1.2.3] - 2023-11-30
 
 ### Fixes

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,52 +1,61 @@
-maven/mavencentral/ch.qos.logback/logback-classic/1.4.13, EPL-1.0 OR LGPL-2.1-only, approved, #3435
-maven/mavencentral/ch.qos.logback/logback-core/1.4.13, EPL-1.0 OR LGPL-2.1-only, approved, #3373
+maven/mavencentral/ch.qos.logback/logback-classic/1.4.14, EPL-1.0 OR LGPL-2.1-only, approved, #3435
+maven/mavencentral/ch.qos.logback/logback-core/1.4.14, EPL-1.0 OR LGPL-2.1-only, approved, #3373
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.15.3, Apache-2.0, approved, #7947
 maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.15.3, MIT AND Apache-2.0, approved, #7932
-maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.13.4.2, Apache-2.0, approved, #2134
+maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.15.3, Apache-2.0, approved, #7934
 maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.15.3, Apache-2.0, approved, #8802
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.15.3, Apache-2.0, approved, #8808
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.15.3, Apache-2.0, approved, #7930
 maven/mavencentral/com.fasterxml.jackson.module/jackson-module-parameter-names/2.15.3, Apache-2.0, approved, #8803
 maven/mavencentral/com.fasterxml/classmate/1.5.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.github.docker-java/docker-java-api/3.3.0, Apache-2.0, approved, #10346
+maven/mavencentral/com.github.docker-java/docker-java-transport-zerodep/3.3.0, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #7946
+maven/mavencentral/com.github.docker-java/docker-java-transport/3.3.0, Apache-2.0, approved, #7942
 maven/mavencentral/com.github.stephenc.jcip/jcip-annotations/1.0-1, Apache-2.0, approved, CQ21949
+maven/mavencentral/com.github.tomakehurst/wiremock-standalone/3.0.0-beta-10, MIT AND Apache-2.0, approved, #9734
 maven/mavencentral/com.google.code.findbugs/jsr305/3.0.2, Apache-2.0, approved, #20
+maven/mavencentral/com.jayway.jsonpath/json-path/2.8.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.nimbusds/content-type/2.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.nimbusds/lang-tag/1.7, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.24.4, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.nimbusds/oauth2-oidc-sdk/9.43.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.opencsv/opencsv/5.7.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.sun.istack/istack-commons-runtime/4.1.2, BSD-3-Clause, approved, #2590
+maven/mavencentral/com.vaadin.external.google/android-json/0.0.20131108.vaadin1, Apache-2.0, approved, CQ21310
 maven/mavencentral/com.zaxxer/HikariCP/5.0.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/commons-codec/commons-codec/1.15, Apache-2.0 AND BSD-3-Clause AND LicenseRef-Public-Domain, approved, CQ22641
 maven/mavencentral/io.hypersistence/hypersistence-tsid/2.0.0, MIT, approved, clearlydefined
 maven/mavencentral/io.hypersistence/hypersistence-utils-hibernate-60/3.5.1, Apache-2.0, approved, #9651
-maven/mavencentral/io.micrometer/micrometer-commons/1.11.5, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #9243
-maven/mavencentral/io.micrometer/micrometer-core/1.11.5, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #9238
-maven/mavencentral/io.micrometer/micrometer-observation/1.11.5, Apache-2.0, approved, #9242
-maven/mavencentral/io.netty/netty-buffer/4.1.100.Final, Apache-2.0, approved, CQ21842
-maven/mavencentral/io.netty/netty-codec-dns/4.1.100.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-codec-http/4.1.100.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-codec-http2/4.1.100.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-codec-socks/4.1.100.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-codec/4.1.100.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-common/4.1.100.Final, Apache-2.0 AND MIT AND CC0-1.0, approved, CQ21843
-maven/mavencentral/io.netty/netty-handler-proxy/4.1.100.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-handler/4.1.100.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-resolver-dns-classes-macos/4.1.100.Final, Apache-2.0, approved, #6367
-maven/mavencentral/io.netty/netty-resolver-dns-native-macos/4.1.100.Final, Apache-2.0, approved, #7004
-maven/mavencentral/io.netty/netty-resolver-dns/4.1.100.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-resolver/4.1.100.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-transport-classes-epoll/4.1.100.Final, Apache-2.0, approved, #6366
-maven/mavencentral/io.netty/netty-transport-native-epoll/4.1.100.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-transport-native-unix-common/4.1.100.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.netty/netty-transport/4.1.100.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.projectreactor.netty/reactor-netty-core/1.1.12, Apache-2.0, approved, #5946
-maven/mavencentral/io.projectreactor.netty/reactor-netty-http/1.1.13, Apache-2.0, approved, #6999
-maven/mavencentral/io.projectreactor/reactor-core/3.5.11, Apache-2.0, approved, #5934
+maven/mavencentral/io.micrometer/micrometer-commons/1.11.7, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #9243
+maven/mavencentral/io.micrometer/micrometer-core/1.11.7, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #9238
+maven/mavencentral/io.micrometer/micrometer-observation/1.11.7, Apache-2.0, approved, #9242
+maven/mavencentral/io.netty/netty-buffer/4.1.104.Final, Apache-2.0, approved, CQ21842
+maven/mavencentral/io.netty/netty-codec-dns/4.1.104.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-codec-http/4.1.104.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-codec-http2/4.1.104.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-codec-socks/4.1.104.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-codec/4.1.104.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-common/4.1.104.Final, Apache-2.0 AND MIT AND CC0-1.0, approved, CQ21843
+maven/mavencentral/io.netty/netty-handler-proxy/4.1.104.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-handler/4.1.104.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-resolver-dns-classes-macos/4.1.104.Final, Apache-2.0, approved, #6367
+maven/mavencentral/io.netty/netty-resolver-dns-native-macos/4.1.104.Final, Apache-2.0, approved, #7004
+maven/mavencentral/io.netty/netty-resolver-dns/4.1.104.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-resolver/4.1.104.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-transport-classes-epoll/4.1.104.Final, Apache-2.0, approved, #6366
+maven/mavencentral/io.netty/netty-transport-native-epoll/4.1.104.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-transport-native-unix-common/4.1.104.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.netty/netty-transport/4.1.104.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+maven/mavencentral/io.projectreactor.netty/reactor-netty-core/1.1.14, Apache-2.0, approved, #5946
+maven/mavencentral/io.projectreactor.netty/reactor-netty-http/1.1.14, Apache-2.0, approved, #6999
+maven/mavencentral/io.projectreactor/reactor-core/3.5.13, Apache-2.0, approved, #5934
+maven/mavencentral/io.smallrye/jandex/3.0.5, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.9, Apache-2.0, approved, #5947
 maven/mavencentral/io.swagger.core.v3/swagger-core-jakarta/2.2.9, Apache-2.0, approved, #5929
 maven/mavencentral/io.swagger.core.v3/swagger-models-jakarta/2.2.9, Apache-2.0, approved, #5919
 maven/mavencentral/jakarta.activation/jakarta.activation-api/2.1.2, EPL-2.0 OR BSD-3-Clause OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jaf
 maven/mavencentral/jakarta.annotation/jakarta.annotation-api/2.1.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.ca
+maven/mavencentral/jakarta.inject/jakarta.inject-api/2.0.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/jakarta.persistence/jakarta.persistence-api/3.1.0, EPL-2.0 OR BSD-3-Clause AND (EPL-2.0 OR BSD-3-Clause AND BSD-3-Clause), approved, #7696
 maven/mavencentral/jakarta.transaction/jakarta.transaction-api/2.0.1, EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, #7697
 maven/mavencentral/jakarta.validation/jakarta.validation-api/3.0.2, Apache-2.0, approved, ee4j.validation
@@ -54,87 +63,126 @@ maven/mavencentral/jakarta.xml.bind/jakarta.xml.bind-api/4.0.1, BSD-3-Clause, ap
 maven/mavencentral/javax.activation/javax.activation-api/1.2.0, (CDDL-1.1 OR GPL-2.0 WITH Classpath-exception-2.0) AND Apache-2.0, approved, CQ18740
 maven/mavencentral/javax.validation/validation-api/2.0.1.Final, Apache-2.0, approved, CQ15302
 maven/mavencentral/javax.xml.bind/jaxb-api/2.3.1, CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, CQ16911
+maven/mavencentral/junit/junit/4.13.2, EPL-2.0, approved, CQ23636
+maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.10, Apache-2.0, approved, #7164
+maven/mavencentral/net.bytebuddy/byte-buddy/1.14.10, Apache-2.0 AND BSD-3-Clause, approved, #7163
+maven/mavencentral/net.java.dev.jna/jna/5.12.1, Apache-2.0 OR LGPL-2.1-or-later, approved, #3217
 maven/mavencentral/net.minidev/accessors-smart/2.4.11, Apache-2.0, approved, #7515
 maven/mavencentral/net.minidev/json-smart/2.4.11, Apache-2.0, approved, #3288
 maven/mavencentral/org.antlr/antlr4-runtime/4.10.1, BSD-3-Clause AND LicenseRef-Public-domain AND MIT AND LicenseRef-Unicode-TOU, approved, #7065
 maven/mavencentral/org.apache.commons/commons-collections4/4.4, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.commons/commons-compress/1.23.0, Apache-2.0 AND BSD-3-Clause, approved, #7506
 maven/mavencentral/org.apache.commons/commons-lang3/3.12.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.commons/commons-text/1.10.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.logging.log4j/log4j-api/2.20.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.logging.log4j/log4j-to-slf4j/2.20.0, Apache-2.0, approved, #8799
-maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-core/10.1.15, Apache-2.0 AND (EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0) AND (CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0) AND W3C AND CC0-1.0, approved, #5949
-maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-el/10.1.15, Apache-2.0, approved, #6997
-maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-websocket/10.1.15, Apache-2.0, approved, #7920
+maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-core/10.1.17, Apache-2.0 AND (EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0) AND (CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0) AND W3C AND CC0-1.0, approved, #5949
+maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-el/10.1.17, Apache-2.0, approved, #6997
+maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-websocket/10.1.17, Apache-2.0, approved, #7920
 maven/mavencentral/org.apiguardian/apiguardian-api/1.1.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.aspectj/aspectjweaver/1.9.20, Apache-2.0 AND BSD-3-Clause AND EPL-1.0 AND BSD-3-Clause AND Apache-1.1, approved, #7695
+maven/mavencentral/org.aspectj/aspectjweaver/1.9.21, Apache-2.0 AND BSD-3-Clause AND EPL-1.0 AND BSD-3-Clause AND Apache-1.1, approved, #7695
+maven/mavencentral/org.assertj/assertj-core/3.24.2, Apache-2.0, approved, #6161
 maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.73, MIT, approved, #7892
 maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.73, MIT, approved, #7894
+maven/mavencentral/org.checkerframework/checker-qual/3.31.0, MIT, approved, clearlydefined
+maven/mavencentral/org.eclipse.angus/angus-activation/2.0.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.angus
+maven/mavencentral/org.glassfish.jaxb/jaxb-core/4.0.4, BSD-3-Clause, approved, ee4j.jaxb
+maven/mavencentral/org.glassfish.jaxb/jaxb-runtime/4.0.4, BSD-3-Clause, approved, ee4j.jaxb
+maven/mavencentral/org.glassfish.jaxb/txw2/4.0.4, BSD-3-Clause, approved, ee4j.jaxb
+maven/mavencentral/org.hamcrest/hamcrest-core/2.2, BSD-3-Clause, approved, clearlydefined
+maven/mavencentral/org.hamcrest/hamcrest/2.2, BSD-3-Clause, approved, clearlydefined
+maven/mavencentral/org.hdrhistogram/HdrHistogram/2.1.12, BSD-2-Clause OR LicenseRef-Public-Domain, approved, CQ13192
+maven/mavencentral/org.hibernate.common/hibernate-commons-annotations/6.0.6.Final, LGPL-2.1-only, approved, #6962
 maven/mavencentral/org.hibernate.orm/hibernate-core/6.2.6.Final, LGPL-2.1-only AND Apache-2.0 AND MIT AND CC-PDDC AND (EPL-2.0 OR BSD-3-Clause), approved, #9121
 maven/mavencentral/org.hibernate.validator/hibernate-validator/8.0.1.Final, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.jboss.logging/jboss-logging/3.5.3.Final, Apache-2.0, approved, #9471
+maven/mavencentral/org.jetbrains/annotations/17.0.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.9.3, EPL-2.0, approved, #3133
+maven/mavencentral/org.junit.jupiter/junit-jupiter-engine/5.9.3, EPL-2.0, approved, #3125
+maven/mavencentral/org.junit.jupiter/junit-jupiter-params/5.9.3, EPL-2.0, approved, #3134
+maven/mavencentral/org.junit.jupiter/junit-jupiter/5.9.3, EPL-2.0, approved, #6972
+maven/mavencentral/org.junit.platform/junit-platform-commons/1.9.3, EPL-2.0, approved, #3130
+maven/mavencentral/org.junit.platform/junit-platform-engine/1.9.3, EPL-2.0, approved, #3128
+maven/mavencentral/org.latencyutils/LatencyUtils/2.0.3, BSD-2-Clause, approved, CQ17408
 maven/mavencentral/org.liquibase/liquibase-core/4.23.0, Apache-2.0, approved, #9650
 maven/mavencentral/org.mapstruct/mapstruct/1.5.5.Final, Apache-2.0, approved, #6277
+maven/mavencentral/org.mockito/mockito-core/5.3.1, MIT AND (Apache-2.0 AND MIT) AND Apache-2.0, approved, #7925
+maven/mavencentral/org.mockito/mockito-junit-jupiter/5.3.1, MIT, approved, clearlydefined
+maven/mavencentral/org.objenesis/objenesis/3.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.openapitools/jackson-databind-nullable/0.2.6, Apache-2.0, approved, #3294
+maven/mavencentral/org.opentest4j/opentest4j/1.2.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.ow2.asm/asm/9.3, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/org.postgresql/postgresql/42.6.0, BSD-2-Clause AND Apache-2.0, approved, #9159
 maven/mavencentral/org.projectlombok/lombok/1.18.28, MIT AND LicenseRef-Public-Domain, approved, CQ23907
 maven/mavencentral/org.reactivestreams/reactive-streams/1.0.4, CC0-1.0, approved, CQ16332
+maven/mavencentral/org.rnorth.duct-tape/duct-tape/1.0.8, MIT, approved, clearlydefined
+maven/mavencentral/org.skyscreamer/jsonassert/1.5.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.slf4j/jul-to-slf4j/2.0.9, MIT, approved, #7698
 maven/mavencentral/org.slf4j/slf4j-api/2.0.9, MIT, approved, #5915
 maven/mavencentral/org.springdoc/springdoc-openapi-starter-common/2.1.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.springdoc/springdoc-openapi-starter-webmvc-api/2.1.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.springdoc/springdoc-openapi-starter-webmvc-ui/2.1.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.springframework.boot/spring-boot-actuator-autoconfigure/3.1.5, Apache-2.0, approved, #9348
-maven/mavencentral/org.springframework.boot/spring-boot-actuator/3.1.5, Apache-2.0, approved, #9342
-maven/mavencentral/org.springframework.boot/spring-boot-autoconfigure/3.1.5, Apache-2.0, approved, #9341
-maven/mavencentral/org.springframework.boot/spring-boot-starter-actuator/3.1.5, Apache-2.0, approved, #9344
-maven/mavencentral/org.springframework.boot/spring-boot-starter-aop/3.1.5, Apache-2.0, approved, #9338
-maven/mavencentral/org.springframework.boot/spring-boot-starter-cache/3.1.5, Apache-2.0, approved, #9653
-maven/mavencentral/org.springframework.boot/spring-boot-starter-data-jpa/3.1.5, Apache-2.0, approved, #9733
-maven/mavencentral/org.springframework.boot/spring-boot-starter-jdbc/3.1.5, Apache-2.0, approved, #9737
-maven/mavencentral/org.springframework.boot/spring-boot-starter-json/3.1.5, Apache-2.0, approved, #9336
-maven/mavencentral/org.springframework.boot/spring-boot-starter-logging/3.1.5, Apache-2.0, approved, #9343
-maven/mavencentral/org.springframework.boot/spring-boot-starter-oauth2-client/3.1.5, Apache-2.0, approved, #8806
-maven/mavencentral/org.springframework.boot/spring-boot-starter-oauth2-resource-server/3.1.5, Apache-2.0, approved, #8804
-maven/mavencentral/org.springframework.boot/spring-boot-starter-reactor-netty/3.1.5, Apache-2.0, approved, #9738
-maven/mavencentral/org.springframework.boot/spring-boot-starter-tomcat/3.1.5, Apache-2.0, approved, #9351
-maven/mavencentral/org.springframework.boot/spring-boot-starter-validation/3.1.5, Apache-2.0, approved, #9335
-maven/mavencentral/org.springframework.boot/spring-boot-starter-web/3.1.5, Apache-2.0, approved, #9347
-maven/mavencentral/org.springframework.boot/spring-boot-starter-webflux/3.1.5, Apache-2.0, approved, #9739
-maven/mavencentral/org.springframework.boot/spring-boot-starter/3.1.5, Apache-2.0, approved, #9349
-maven/mavencentral/org.springframework.boot/spring-boot/3.1.5, Apache-2.0, approved, #9352
+maven/mavencentral/org.springframework.boot/spring-boot-actuator-autoconfigure/3.1.7, Apache-2.0, approved, #9348
+maven/mavencentral/org.springframework.boot/spring-boot-actuator/3.1.7, Apache-2.0, approved, #9342
+maven/mavencentral/org.springframework.boot/spring-boot-autoconfigure/3.1.7, Apache-2.0, approved, #9341
+maven/mavencentral/org.springframework.boot/spring-boot-starter-actuator/3.1.7, Apache-2.0, approved, #9344
+maven/mavencentral/org.springframework.boot/spring-boot-starter-aop/3.1.7, Apache-2.0, approved, #9338
+maven/mavencentral/org.springframework.boot/spring-boot-starter-cache/3.1.7, Apache-2.0, approved, #9653
+maven/mavencentral/org.springframework.boot/spring-boot-starter-data-jpa/3.1.7, Apache-2.0, approved, #9733
+maven/mavencentral/org.springframework.boot/spring-boot-starter-jdbc/3.1.7, Apache-2.0, approved, #9737
+maven/mavencentral/org.springframework.boot/spring-boot-starter-json/3.1.7, Apache-2.0, approved, #9336
+maven/mavencentral/org.springframework.boot/spring-boot-starter-logging/3.1.7, Apache-2.0, approved, #9343
+maven/mavencentral/org.springframework.boot/spring-boot-starter-oauth2-client/3.1.7, Apache-2.0, approved, #8806
+maven/mavencentral/org.springframework.boot/spring-boot-starter-oauth2-resource-server/3.1.7, Apache-2.0, approved, #8804
+maven/mavencentral/org.springframework.boot/spring-boot-starter-reactor-netty/3.1.7, Apache-2.0, approved, #9738
+maven/mavencentral/org.springframework.boot/spring-boot-starter-test/3.1.7, Apache-2.0, approved, #9353
+maven/mavencentral/org.springframework.boot/spring-boot-starter-tomcat/3.1.7, Apache-2.0, approved, #9351
+maven/mavencentral/org.springframework.boot/spring-boot-starter-validation/3.1.7, Apache-2.0, approved, #9335
+maven/mavencentral/org.springframework.boot/spring-boot-starter-web/3.1.7, Apache-2.0, approved, #9347
+maven/mavencentral/org.springframework.boot/spring-boot-starter-webflux/3.1.7, Apache-2.0, approved, #9739
+maven/mavencentral/org.springframework.boot/spring-boot-starter/3.1.7, Apache-2.0, approved, #9349
+maven/mavencentral/org.springframework.boot/spring-boot-test-autoconfigure/3.1.7, Apache-2.0, approved, #9339
+maven/mavencentral/org.springframework.boot/spring-boot-test/3.1.7, Apache-2.0, approved, #9346
+maven/mavencentral/org.springframework.boot/spring-boot/3.1.7, Apache-2.0, approved, #9352
 maven/mavencentral/org.springframework.cloud/spring-cloud-commons/4.0.4, Apache-2.0, approved, #7292
 maven/mavencentral/org.springframework.cloud/spring-cloud-context/4.0.4, Apache-2.0, approved, #7306
 maven/mavencentral/org.springframework.cloud/spring-cloud-starter-bootstrap/4.0.4, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.springframework.cloud/spring-cloud-starter/4.0.4, Apache-2.0, approved, #7299
-maven/mavencentral/org.springframework.data/spring-data-commons/3.1.5, Apache-2.0, approved, #8805
-maven/mavencentral/org.springframework.data/spring-data-jpa/3.1.5, Apache-2.0, approved, #9120
+maven/mavencentral/org.springframework.data/spring-data-commons/3.1.7, Apache-2.0, approved, #8805
+maven/mavencentral/org.springframework.data/spring-data-jpa/3.1.7, Apache-2.0, approved, #9120
 maven/mavencentral/org.springframework.security.oauth/spring-security-oauth2/2.5.2.RELEASE, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.springframework.security/spring-security-config/6.1.5, Apache-2.0, approved, #9736
-maven/mavencentral/org.springframework.security/spring-security-core/6.1.5, Apache-2.0, approved, #9801
-maven/mavencentral/org.springframework.security/spring-security-crypto/6.1.5, Apache-2.0 AND ISC, approved, #9735
-maven/mavencentral/org.springframework.security/spring-security-oauth2-client/6.1.5, Apache-2.0, approved, #9740
-maven/mavencentral/org.springframework.security/spring-security-oauth2-core/6.1.5, Apache-2.0, approved, #9741
-maven/mavencentral/org.springframework.security/spring-security-oauth2-jose/6.1.5, Apache-2.0, approved, #9345
-maven/mavencentral/org.springframework.security/spring-security-oauth2-resource-server/6.1.5, Apache-2.0, approved, #8798
+maven/mavencentral/org.springframework.security/spring-security-config/6.1.6, Apache-2.0, approved, #9736
+maven/mavencentral/org.springframework.security/spring-security-core/6.1.6, Apache-2.0, approved, #9801
+maven/mavencentral/org.springframework.security/spring-security-crypto/6.1.6, Apache-2.0 AND ISC, approved, #9735
+maven/mavencentral/org.springframework.security/spring-security-oauth2-client/6.1.6, Apache-2.0, approved, #9740
+maven/mavencentral/org.springframework.security/spring-security-oauth2-core/6.1.6, Apache-2.0, approved, #9741
+maven/mavencentral/org.springframework.security/spring-security-oauth2-jose/6.1.6, Apache-2.0, approved, #9345
+maven/mavencentral/org.springframework.security/spring-security-oauth2-resource-server/6.1.6, Apache-2.0, approved, #8798
 maven/mavencentral/org.springframework.security/spring-security-rsa/1.0.12.RELEASE, Apache-2.0, approved, CQ20647
-maven/mavencentral/org.springframework.security/spring-security-web/6.1.1, Apache-2.0, approved, #9800
-maven/mavencentral/org.springframework/spring-aop/6.0.13, Apache-2.0, approved, #5940
-maven/mavencentral/org.springframework/spring-aspects/6.0.13, Apache-2.0, approved, #5930
-maven/mavencentral/org.springframework/spring-beans/6.0.13, Apache-2.0, approved, #5937
-maven/mavencentral/org.springframework/spring-context-support/6.0.13, Apache-2.0, approved, #6960
-maven/mavencentral/org.springframework/spring-context/6.0.13, Apache-2.0, approved, #5936
-maven/mavencentral/org.springframework/spring-core/6.0.8, Apache-2.0 AND BSD-3-Clause, approved, #5948
-maven/mavencentral/org.springframework/spring-expression/6.0.8, Apache-2.0, approved, #3284
-maven/mavencentral/org.springframework/spring-jcl/6.0.13, Apache-2.0, approved, #3283
-maven/mavencentral/org.springframework/spring-jdbc/6.0.13, Apache-2.0, approved, #5924
-maven/mavencentral/org.springframework/spring-orm/6.0.13, Apache-2.0, approved, #5925
-maven/mavencentral/org.springframework/spring-tx/6.0.13, Apache-2.0, approved, #5926
-maven/mavencentral/org.springframework/spring-web/6.0.13, Apache-2.0, approved, #5942
-maven/mavencentral/org.springframework/spring-webflux/6.0.13, Apache-2.0, approved, #6964
-maven/mavencentral/org.springframework/spring-webmvc/6.0.13, Apache-2.0, approved, #5944
+maven/mavencentral/org.springframework.security/spring-security-web/6.2.1, Apache-2.0, approved, #11911
+maven/mavencentral/org.springframework/spring-aop/6.0.15, Apache-2.0, approved, #5940
+maven/mavencentral/org.springframework/spring-aspects/6.0.15, Apache-2.0, approved, #5930
+maven/mavencentral/org.springframework/spring-beans/6.0.15, Apache-2.0, approved, #5937
+maven/mavencentral/org.springframework/spring-context-support/6.0.15, Apache-2.0, approved, #6960
+maven/mavencentral/org.springframework/spring-context/6.0.15, Apache-2.0, approved, #5936
+maven/mavencentral/org.springframework/spring-core/6.0.15, Apache-2.0 AND BSD-3-Clause, approved, #5948
+maven/mavencentral/org.springframework/spring-expression/6.0.15, Apache-2.0, approved, #3284
+maven/mavencentral/org.springframework/spring-jcl/6.0.15, Apache-2.0, approved, #3283
+maven/mavencentral/org.springframework/spring-jdbc/6.0.15, Apache-2.0, approved, #5924
+maven/mavencentral/org.springframework/spring-orm/6.0.15, Apache-2.0, approved, #5925
+maven/mavencentral/org.springframework/spring-test/6.0.15, Apache-2.0, approved, #7003
+maven/mavencentral/org.springframework/spring-tx/6.0.15, Apache-2.0, approved, #5926
+maven/mavencentral/org.springframework/spring-web/6.0.15, Apache-2.0, approved, #5942
+maven/mavencentral/org.springframework/spring-webflux/6.0.15, Apache-2.0, approved, #6964
+maven/mavencentral/org.springframework/spring-webmvc/6.0.15, Apache-2.0, approved, #5944
+maven/mavencentral/org.testcontainers/database-commons/1.18.3, MIT, approved, clearlydefined
+maven/mavencentral/org.testcontainers/jdbc/1.18.3, MIT, approved, clearlydefined
+maven/mavencentral/org.testcontainers/junit-jupiter/1.18.3, MIT, approved, #7941
+maven/mavencentral/org.testcontainers/postgresql/1.18.3, MIT, approved, #9332
+maven/mavencentral/org.testcontainers/testcontainers/1.18.3, MIT, approved, #7938
 maven/mavencentral/org.webjars/swagger-ui/4.18.2, Apache-2.0, approved, #7850
-maven/mavencentral/org.yaml/snakeyaml/2.0, Apache-2.0 AND (Apache-2.0 OR BSD-3-Clause OR EPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later), approved, #7275
+maven/mavencentral/org.xmlunit/xmlunit-core/2.9.1, Apache-2.0, approved, #6272
+maven/mavencentral/org.yaml/snakeyaml/2.2, Apache-2.0 AND (Apache-2.0 OR BSD-3-Clause OR EPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later), approved, #10232
 maven/mavencentral/org.zalando/faux-pas/0.8.0, MIT, approved, clearlydefined
 maven/mavencentral/org.zalando/jackson-datatype-problem/0.24.0, MIT, approved, clearlydefined
 maven/mavencentral/org.zalando/problem-spring-common/0.26.0, MIT, approved, clearlydefined

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <liquibase.version>4.23.0</liquibase.version>
         <liquibase-hibernate5.version>4.22.0</liquibase-hibernate5.version>
         <spring-boot.version>3.1.7</spring-boot.version>
-        <org.zalando.problem-spring-web>0.26.0</org.zalando.problem-spring-web>
+        <org.zalando.problem-spring-web>0.27.0</org.zalando.problem-spring-web>
         <org.springdoc.springdoc-openapi-ui>2.1.0</org.springdoc.springdoc-openapi-ui>
         <org.springframework.cloud>4.0.4</org.springframework.cloud>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
@@ -333,11 +333,6 @@
                         </goals>
                     </execution>
                 </executions>
-                <configuration>
-                    <projectId>automotive.tractusx</projectId>
-                    <summary>DEPENDENCIES</summary>
-                    <includeScope>test</includeScope>
-                </configuration>
             </plugin>
             <!--			<plugin>-->
             <!--				&lt;!&ndash;-->

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <liquibase.version>4.23.0</liquibase.version>
         <liquibase-hibernate5.version>4.22.0</liquibase-hibernate5.version>
         <spring-boot.version>3.1.7</spring-boot.version>
-        <org.zalando.problem-spring-web>0.27.0</org.zalando.problem-spring-web>
+        <org.zalando.problem-spring-web>0.26.0</org.zalando.problem-spring-web>
         <org.springdoc.springdoc-openapi-ui>2.1.0</org.springdoc.springdoc-openapi-ui>
         <org.springframework.cloud>4.0.4</org.springframework.cloud>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
@@ -72,7 +72,7 @@
     <pluginRepositories>
         <pluginRepository>
             <id>dash-licenses-snapshots</id>
-            <url>https://repo.eclipse.org/content/repositories/dash-licenses-snapshots/org/eclipse/dash/license-tool-plugin/</url>
+            <url>https://repo.eclipse.org/content/repositories/dash-licenses/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
@@ -324,7 +324,7 @@
             <plugin>
                 <groupId>org.eclipse.dash</groupId>
                 <artifactId>license-tool-plugin</artifactId>
-                <version>1.1.1-SNAPSHOT</version>
+                <version>1.0.2</version>
                 <executions>
                     <execution>
                         <id>license-check</id>
@@ -333,6 +333,11 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <projectId>automotive.tractusx</projectId>
+                    <summary>DEPENDENCIES</summary>
+                    <includeScope>test</includeScope>
+                </configuration>
             </plugin>
             <!--			<plugin>-->
             <!--				&lt;!&ndash;-->

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.7</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>org.eclipse.tractusx</groupId>
@@ -38,7 +38,7 @@
         <org.projectlombok.version>1.18.28</org.projectlombok.version>
         <liquibase.version>4.23.0</liquibase.version>
         <liquibase-hibernate5.version>4.22.0</liquibase-hibernate5.version>
-        <spring-boot.version>3.1.5</spring-boot.version>
+        <spring-boot.version>3.1.7</spring-boot.version>
         <org.zalando.problem-spring-web>0.26.0</org.zalando.problem-spring-web>
         <org.springdoc.springdoc-openapi-ui>2.1.0</org.springdoc.springdoc-openapi-ui>
         <org.springframework.cloud>4.0.4</org.springframework.cloud>
@@ -52,33 +52,27 @@
             src/main/java/org/eclipse/tractusx/valueaddedservice/dto//.,src/main/java/org/eclipse/tractusx/valueaddedservice/domain//.¨
         </sonar1.coverage.exclusions>
         <jacoco.version>0.8.7</jacoco.version>
-        <spring-boot-starter-oauth2>3.1.5</spring-boot-starter-oauth2>
-        <spring-security-web-version>6.1.1</spring-security-web-version>
+
+        <spring-security-web-version>6.2.1</spring-security-web-version>
         <postgresql-version>42.6.0</postgresql-version>
-        <jackson-databind>2.13.4.2</jackson-databind>
         <jackson-databind-nullable>0.2.6</jackson-databind-nullable>
         <wiremock-standalone-version>3.0.0-beta-10</wiremock-standalone-version>
-        <snake-yaml-version>2.0</snake-yaml-version>
-        <commons-fileupload-version>1.5</commons-fileupload-version>
+        <snake-yaml-version>2.2</snake-yaml-version>
         <openapi-generator-maven-plugin.version>6.2.1</openapi-generator-maven-plugin.version>
         <hibernate-core-version>6.2.6.Final</hibernate-core-version>
         <hypersistence-utils-hibernate-60>3.5.1</hypersistence-utils-hibernate-60>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <testcontainers.version>1.18.3</testcontainers.version>
-        <spring-expression-version>6.0.8</spring-expression-version>
-        <spring-core-version>6.0.8</spring-core-version>
-        <spring-security-core-version>6.1.5</spring-security-core-version>
         <springdoc-openapi-starter-webmvc-ui>2.1.0</springdoc-openapi-starter-webmvc-ui>
         <org.owasp.antisamy>1.7.4</org.owasp.antisamy>
-        <io.projectreactor.netty>1.1.13</io.projectreactor.netty>
-        <ch.qos.logback>1.4.13</ch.qos.logback>
+
     </properties>
 
     <pluginRepositories>
         <pluginRepository>
             <id>dash-licenses-snapshots</id>
-            <url>https://repo.eclipse.org/content/repositories/dash-licenses-snapshots/</url>
+            <url>https://repo.eclipse.org/content/repositories/dash-licenses-snapshots/org/eclipse/dash/license-tool-plugin/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
@@ -88,60 +82,17 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.springframework.security</groupId>
-                <artifactId>spring-security-core</artifactId>
-                <version>${spring-security-web-version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>${jackson-databind}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
                 <version>${snake-yaml-version}</version>
             </dependency>
-            <dependency>
-                <groupId>commons-fileupload</groupId>
-                <artifactId>commons-fileupload</artifactId>
-                <version>${commons-fileupload-version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-expression</artifactId>
-                <version>${spring-expression-version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-core</artifactId>
-                <version>${spring-core-version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.security</groupId>
-                <artifactId>spring-security-core</artifactId>
-                <version>${spring-security-core-version}</version>
-            </dependency>
+
             <dependency>
                 <groupId>org.owasp.antisamy</groupId>
                 <artifactId>antisamy</artifactId>
                 <version>${org.owasp.antisamy}</version>
             </dependency>
-            <dependency>
-                <groupId>io.projectreactor.netty</groupId>
-                <artifactId>reactor-netty-http</artifactId>
-                <version>${io.projectreactor.netty}</version>
-            </dependency>
-            <dependency>
-                <groupId>ch.qos.logback</groupId>
-                <artifactId>logback-classic</artifactId>
-                <version>${ch.qos.logback}</version>
-            </dependency>
-            <dependency>
-                <groupId>ch.qos.logback</groupId>
-                <artifactId>logback-core</artifactId>
-                <version>${ch.qos.logback}</version>
-            </dependency>
+
         </dependencies>
 
     </dependencyManagement>
@@ -212,12 +163,12 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
-            <version>${spring-boot-starter-oauth2}</version>
+            <version>${spring-boot.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-oauth2-client</artifactId>
-            <version>${spring-boot-starter-oauth2}</version>
+            <version>${spring-boot.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -373,7 +324,7 @@
             <plugin>
                 <groupId>org.eclipse.dash</groupId>
                 <artifactId>license-tool-plugin</artifactId>
-                <version>0.0.1-SNAPSHOT</version>
+                <version>1.1.1-SNAPSHOT</version>
                 <executions>
                     <execution>
                         <id>license-check</id>
@@ -382,6 +333,11 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <projectId>automotive.tractusx</projectId>
+                    <summary>DEPENDENCIES</summary>
+                    <includeScope>test</includeScope>
+                </configuration>
             </plugin>
             <!--			<plugin>-->
             <!--				&lt;!&ndash;-->

--- a/src/main/java/org/eclipse/tractusx/valueaddedservice/config/ObjectMapperConfig.java
+++ b/src/main/java/org/eclipse/tractusx/valueaddedservice/config/ObjectMapperConfig.java
@@ -26,7 +26,7 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.zalando.problem.ProblemModule;
+import org.zalando.problem.jackson.ProblemModule;
 import org.zalando.problem.violations.ConstraintViolationProblemModule;
 
 @Configuration

--- a/src/main/java/org/eclipse/tractusx/valueaddedservice/config/ObjectMapperConfig.java
+++ b/src/main/java/org/eclipse/tractusx/valueaddedservice/config/ObjectMapperConfig.java
@@ -26,7 +26,7 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.zalando.problem.jackson.ProblemModule;
+import org.zalando.problem.ProblemModule;
 import org.zalando.problem.violations.ConstraintViolationProblemModule;
 
 @Configuration


### PR DESCRIPTION
## Description
Updating of libs that contain vulnerability's 
Both VeraCode and Trivy tools examined the new changes code

https://github.com/eclipse-tractusx/vas-country-risk-backend/issues/66

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
