### PR TITLE
fix(backend): Upgrade backend version of postgres

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -111,7 +111,7 @@ maven/mavencentral/org.objenesis/objenesis/3.3, Apache-2.0, approved, clearlydef
 maven/mavencentral/org.openapitools/jackson-databind-nullable/0.2.6, Apache-2.0, approved, #3294
 maven/mavencentral/org.opentest4j/opentest4j/1.3.0, Apache-2.0, approved, #9713
 maven/mavencentral/org.ow2.asm/asm/9.3, BSD-3-Clause, approved, clearlydefined
-maven/mavencentral/org.postgresql/postgresql/42.7.2, BSD-2-Clause AND Apache-2.0, approved, #11681
+maven/mavencentral/org.postgresql/postgresql/42.7.3, BSD-2-Clause AND Apache-2.0, approved, #11681
 maven/mavencentral/org.projectlombok/lombok/1.18.28, MIT AND LicenseRef-Public-Domain, approved, CQ23907
 maven/mavencentral/org.reactivestreams/reactive-streams/1.0.4, CC0-1.0, approved, CQ16332
 maven/mavencentral/org.rnorth.duct-tape/duct-tape/1.0.8, MIT, approved, clearlydefined

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <jacoco.version>0.8.7</jacoco.version>
 
         <spring-security-web-version>6.2.3</spring-security-web-version>
-        <postgresql-version>42.7.2</postgresql-version>
+        <postgresql-version>42.7.3</postgresql-version>
         <jackson-databind-nullable>0.2.6</jackson-databind-nullable>
         <wiremock-standalone-version>3.0.0-beta-10</wiremock-standalone-version>
         <snake-yaml-version>2.2</snake-yaml-version>


### PR DESCRIPTION
## Description
Update version of postgres

Fix: https://github.com/eclipse-tractusx/vas-country-risk-backend/issues/33

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
